### PR TITLE
chore(step-3): add path aliases, env wiring, and update plan

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -145,15 +145,15 @@ node -v
 
 ## Step 3 – Configuration (aliases, env, constants)
 
-- [ ] Step 3 complete
+- [X] Step 3 complete
 
 **Goal**: Establish path aliases, environment variables, and base constants.
 
 **Tasks**
 
-- [ ] Add `jsconfig.json` path aliases (`@assets`, `@config`, `@data`, `@presentation`, `@store`, `@utils`, `@services`, `@navigation`)
-- [ ] Add `.env`, `.env.development`, `.env.production`
-- [ ] Implement `config/constants/*`, `config/api.js`, `config/routes.js`, `config/environment.js`
+- [X] Add `jsconfig.json` path aliases (`@assets`, `@config`, `@data`, `@presentation`, `@store`, `@utils`, `@services`, `@navigation`)
+- [X] Add `.env`, `.env.development`, `.env.production`
+- [X] Implement `config/constants/*`, `config/api.js`, `config/routes.js`, `config/environment.js`
 
 **Notes**
 
@@ -165,8 +165,8 @@ node -v
 
 **Definition of Done**
 
-- [ ] Imports resolve via aliases
-- [ ] App reads env vars correctly
+- [X] Imports resolve via aliases
+- [X] App reads env vars correctly
 
 ---
 

--- a/react-app/jsconfig.json
+++ b/react-app/jsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@assets/*": ["src/assets/*"],
+      "@config/*": ["src/config/*"],
+      "@data/*": ["src/data/*"],
+      "@presentation/*": ["src/presentation/*"],
+      "@store/*": ["src/store/*"],
+      "@utils/*": ["src/utils/*"],
+      "@services/*": ["src/services/*"],
+      "@navigation/*": ["src/navigation/*"]
+    }
+  },
+  "include": ["src"]
+}
+

--- a/react-app/src/config/api.js
+++ b/react-app/src/config/api.js
@@ -1,1 +1,10 @@
-export const API = { baseURL: '', endpoints: {} };
+const baseURL = import.meta.env.VITE_API_BASE_URL || '';
+
+export const API = {
+  baseURL,
+  endpoints: {}
+};
+
+export function getApiBaseUrl() {
+  return baseURL;
+}

--- a/react-app/vite.config.js
+++ b/react-app/vite.config.js
@@ -4,4 +4,16 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@assets': '/src/assets',
+      '@config': '/src/config',
+      '@data': '/src/data',
+      '@presentation': '/src/presentation',
+      '@store': '/src/store',
+      '@utils': '/src/utils',
+      '@services': '/src/services',
+      '@navigation': '/src/navigation'
+    }
+  }
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Vite/jsconfig path aliases, wires API base URL from env, and marks Step 3 complete in the project plan.
> 
> - **Config**:
>   - **Path Aliases**: Add aliases in `react-app/vite.config.js` and `react-app/jsconfig.json` for `@assets`, `@config`, `@data`, `@presentation`, `@store`, `@utils`, `@services`, `@navigation`.
>   - **API Config**: Update `src/config/api.js` to read base URL from `import.meta.env.VITE_API_BASE_URL` and export `getApiBaseUrl()`.
> - **Docs**:
>   - Mark Step 3 tasks and DoD as complete in `docs/PROJECT_PLAN.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dee2e743527f8279eac5d1598ad29a92c7213922. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->